### PR TITLE
Expand inventory slots and remove weight system

### DIFF
--- a/inventory/lua/autorun/client/inv_bank_gui.lua
+++ b/inventory/lua/autorun/client/inv_bank_gui.lua
@@ -15,14 +15,7 @@ if CLIENT then
     Invenotry_Gui.BankFrame:SetDeleteOnClose(false)  
     Invenotry_Gui.BankFrame:SetVisible(false)  
  
-    local WeightLabel = vgui.Create("DLabel", Invenotry_Gui.BankFrame) 
-    local fx, fy = Invenotry_Gui.BankFrame:GetSize()
-    WeightLabel:SetSize(fx, 50)
-    WeightLabel:SetPos(0,fy-55)  
-    WeightLabel:SetContentAlignment( 5 )  
-    WeightLabel:SetColor(InventoryConfig.Colors.textColor)
-    WeightLabel:SetFont("WeightFont")               
-    WeightLabel:SetText(InventoryConfig.GuiText.totalWeight.."0 / "..getMaxWeight(LocalPlayer(), "Хранилище").." кг")
+    -- Weight system removed
 
     net.Receive( "openBankGui", function( len, player )
         local invW, invH = Invenotry_Gui.InvFrame:GetSize()
@@ -44,19 +37,16 @@ if CLIENT then
     local lastTime=0  
     function refreshBank(tab)
         if tab ~= nil then
-            local totalWeight = 0
-            for i = 1, 32 do 
-                LocalPlayer().BankSlots[i].IsOccupied  = tab[i].IsOccupied 
-                LocalPlayer().BankSlots[i].VGui:SetCount(tab[i].Count)  
+            for i = 1, 32 do
+                LocalPlayer().BankSlots[i].IsOccupied  = tab[i].IsOccupied
+                LocalPlayer().BankSlots[i].VGui:SetCount(tab[i].Count)
                 if tab[i].Model ~= nil and tab[i].Count > 0 then
-                    LocalPlayer().BankSlots[i].VGui:SetModel(tab[i].Model) 
-                end 
-                LocalPlayer().BankSlots[i].VGui:SetName(tab[i].Name) 
-                LocalPlayer().BankSlots[i].VGui:SetItemClass(tab[i].ItemClass) 
-                LocalPlayer().BankSlots[i].VGui:SetWeaponClass(tab[i].WeaponClass) 
-                totalWeight = (totalWeight + (tonumber(tab[i].SingleWeight) * tonumber(tab[i].Count)))
-            end 
-            WeightLabel:SetText(InventoryConfig.GuiText.totalWeight..totalWeight.." / "..getMaxWeight(LocalPlayer(), "Хранилище").." кг")
+                    LocalPlayer().BankSlots[i].VGui:SetModel(tab[i].Model)
+                end
+                LocalPlayer().BankSlots[i].VGui:SetName(tab[i].Name)
+                LocalPlayer().BankSlots[i].VGui:SetItemClass(tab[i].ItemClass)
+                LocalPlayer().BankSlots[i].VGui:SetWeaponClass(tab[i].WeaponClass)
+            end
         end
     end 
     net.Receive( "forceRefresh_bank", function( len, ply ) refreshBank(net.ReadTable())  end)
@@ -84,8 +74,8 @@ if CLIENT then
                  ply.BankSlots[e].VGui:SetAlpha(255) 
                 end
             end
-            for e = 1, 16 do
-                ply.InventorySlots[e].VGui:SetAlpha(255) 
+            for e = 1, 40 do
+                ply.InventorySlots[e].VGui:SetAlpha(255)
             end
             if drop then
                 -- drop na bank  
@@ -109,8 +99,8 @@ if CLIENT then
                  ply.BankSlots[e].VGui:SetAlpha(255) 
                 end
             end
-            for e = 1, 16 do
-                ply.InventorySlots[e].VGui:SetAlpha(255) 
+            for e = 1, 40 do
+                ply.InventorySlots[e].VGui:SetAlpha(255)
             end
             if drop then
                 net.Start("swapItems_inv")

--- a/inventory/lua/autorun/client/inv_gui.lua
+++ b/inventory/lua/autorun/client/inv_gui.lua
@@ -19,21 +19,11 @@ if CLIENT then
             Invenotry_Gui.InvFrame:SetDeleteOnClose(false)
             Invenotry_Gui.InvFrame:SetVisible(false)
 
-            local WeightLabel = vgui.Create("DLabel", Invenotry_Gui.InvFrame)
-            local fx, fy = Invenotry_Gui.InvFrame:GetSize()
-            WeightLabel:SetSize(fx, 50)
-            WeightLabel:SetPos(0, fy - 55)
-            WeightLabel:SetContentAlignment(5)
-            WeightLabel:SetFont("WeightFont")
-            WeightLabel:SetColor(InventoryConfig.Colors.textColor)
-            WeightLabel:SetText(
-                InventoryConfig.GuiText.totalWeight .. "0 / " .. getMaxWeight(LocalPlayer(), "Рюкзак") .. " кг"
-            )
+            -- Weight system removed
             local lastTime = 0
             function refreshInv(tab)
                 if tab ~= nil then
-                    local totalWeight = 0
-                    for i = 1, 16 do
+                    for i = 1, 40 do
                         LocalPlayer().InventorySlots[i].IsOccupied = tab[i].IsOccupied
                         LocalPlayer().InventorySlots[i].VGui:SetCount(tab[i].Count)
                         if tab[i].Model ~= nil and tab[i].Count > 0 then
@@ -43,12 +33,7 @@ if CLIENT then
                         LocalPlayer().InventorySlots[i].VGui:SetName(tab[i].Name)
                         LocalPlayer().InventorySlots[i].VGui:SetItemClass(tab[i].ItemClass)
                         LocalPlayer().InventorySlots[i].VGui:SetWeaponClass(tab[i].WeaponClass)
-                        totalWeight = (totalWeight + (tonumber(tab[i].SingleWeight) * tonumber(tab[i].Count)))
                     end
-                    WeightLabel:SetText( 
-                        InventoryConfig.GuiText.totalWeight ..
-                            totalWeight .. " / " .. getMaxWeight(LocalPlayer(), "Inventory") .. " кг"
-                    )
                 end
             end
             net.Receive(
@@ -87,7 +72,7 @@ if CLIENT then
                             else
                                 net.Start("inv_requestUpdate")
                                 net.SendToServer()
-                                for e = 1, 16 do
+                                for e = 1, 40 do
                                     ply.InventorySlots[e].VGui:SetAlpha(255)
                                 end
                                 for e = 1, 32 do
@@ -106,13 +91,17 @@ if CLIENT then
             end
             hook.Add("Think", "bindThinkInv", bindThinkInv)
 
-            local grid = vgui.Create("DGrid", Invenotry_Gui.InvFrame)
-            grid:SetPos(10 * scale, 30 * scale)
+            local scroll = vgui.Create("DScrollPanel", Invenotry_Gui.InvFrame)
+            scroll:SetPos(10 * scale, 30 * scale)
+            scroll:SetSize(72 * 4, 72 * 4)
+
+            local grid = vgui.Create("DGrid", scroll)
+            grid:Dock(FILL)
             grid:SetCols(4)
             grid:SetColWide(72)
             grid:SetRowHeight(72)
 
-            for i = 1, 16 do
+            for i = 1, 40 do
                 ply.InventorySlots[i] = {}
                 ply.InventorySlots[i].VGui = vgui.Create("inv_slot", Invenotry_Gui.InvFrame)
                 ply.InventorySlots[i].IsOccupied = false
@@ -125,11 +114,11 @@ if CLIENT then
                     function(pnl, item, drop, i, x, y)
                         item = item[1]
                         if pnl.Id == nil then
-                            for e = 1, 16 do
+                            for e = 1, 40 do
                                 ply.InventorySlots[e].VGui:SetAlpha(255)
                             end
                         end
-                        for e = 1, 16 do
+                        for e = 1, 40 do
                             if ply.InventorySlots[e].VGui.Id == pnl.Id then
                                 ply.InventorySlots[e].VGui:SetAlpha(100)
                             else
@@ -155,7 +144,7 @@ if CLIENT then
                     "inv_droppingFromBank",
                     function(pnl, item, drop, i, x, y)
                         item = item[1]
-                        for e = 1, 16 do
+                        for e = 1, 40 do
                             if ply.InventorySlots[e].VGui.Id == pnl.Id then
                                 ply.InventorySlots[e].VGui:SetAlpha(100)
                             else

--- a/inventory/lua/autorun/client/inv_init_c.lua
+++ b/inventory/lua/autorun/client/inv_init_c.lua
@@ -30,10 +30,10 @@ end
 
 hook.Add( "Think", "clearAlphaIfNeeded", function()
     if not input.IsMouseDown(MOUSE_LEFT) and (Invenotry_Gui.InvFrame:IsVisible() or Invenotry_Gui.BankFrame:IsVisible()) then
-        for e=1,32 do  
+        for e=1,32 do
             LocalPlayer().BankSlots[e].VGui:SetAlpha(255)
         end
-        for e=1,16 do   
+        for e=1,40 do
             LocalPlayer().InventorySlots[e].VGui:SetAlpha(255)
         end
     end

--- a/inventory/lua/autorun/server/inv_init.lua
+++ b/inventory/lua/autorun/server/inv_init.lua
@@ -29,26 +29,26 @@ if SERVER then
         net.WriteString(msg)
         net.Send(ply) 
     end
-    local function getTotalWeight(tab)
-        local totalWeight = 0
-        for i, val in ipairs(tab) do
-            totalWeight = totalWeight+(val.SingleWeight * val.Count)
-        end 
-        return totalWeight
-    end
+    -- Weight related functions removed
 
     local function saveData()end
     local function loadData(ply, typ) 
         if file.Exists( InventoryConfig.General.playerDataFolder.."/"..ply:SteamID64().."_"..typ..".dat", "DATA" ) then
-            return util.JSONToTable(file.Read( InventoryConfig.General.playerDataFolder.."/"..ply:SteamID64().."_"..typ..".dat", "DATA" ))
+            local data = util.JSONToTable(file.Read( InventoryConfig.General.playerDataFolder.."/"..ply:SteamID64().."_"..typ..".dat", "DATA" ))
+            if typ == "Inventory" and #data < 40 then
+                for i = #data + 1, 40 do
+                    data[i] = {isOccupied = false, Count = 0, Name = "unknown", ItemClass = "unknown", WeaponClass = "unknown", SingleWeight = 0}
+                end
+            end
+            return data
         else
             local eq = {}
             local range=0
-            if typ == "Inventory" then range = 16 else range = 32 end
+            if typ == "Inventory" then range = 40 else range = 32 end
             for i=1,range do
                 eq[i] = {}
-                eq[i].isOccupied = false 
-                eq[i].Count = 0 
+                eq[i].isOccupied = false
+                eq[i].Count = 0
                 eq[i].Name = "unknown"
                 eq[i].ItemClass = "unknown"
                 eq[i].WeaponClass = "unknown"
@@ -180,54 +180,50 @@ if SERVER then
     local plyMeta = FindMetaTable( "Player" )         
     function plyMeta:AddInventoryItem(ent, count)
         local eq = loadData(self,"Inventory")  
-        if eq == nil then 
-            eq = {} 
-            for i=1,16 do
+        if eq == nil then
+            eq = {}
+            for i=1,40 do
                 eq[i] = {}
-                eq[i].isOccupied = false 
+                eq[i].isOccupied = false
                 eq[i].Count = 0
                 eq[i].Name = "unknown"
                 eq[i].ItemClass = "unknown"
                 eq[i].WeaponClass = "unknown"
                 eq[i].SingleWeight = 0
             end
-        end 
-        local totalWeight = getTotalWeight(eq)
+        end
         for i, slot in ipairs(eq) do
             if ent.StackSize == nil then ent.StackSize = 1 end
-            if slot.isOccupied == false or (ent.StackSize > slot.Count and slot.ItemClass == ent:GetClass()) then 
+            if slot.isOccupied == false or (ent.StackSize > slot.Count and slot.ItemClass == ent:GetClass()) then
                 if ent.Weight ~= nil then
                     slot.SingleWeight = ent.Weight
                 else
                     slot.SingleWeight = 1
                 end
-                if (slot.SingleWeight + totalWeight) <= getMaxWeight(self, "Inventory") then 
-                    slot.isOccupied = true
-                    if ent.Name ~= nil then slot.Name = ent.Name else
-                        slot.Name = ent:GetClass()
-                    end
-                    slot.ItemClass = ent:GetClass() 
-                    slot.Count = slot.Count + 1
-                    slot.Model = ent:GetModel() 
-                    slot.MaxStack = ent.StackSize
-                    if slot.ItemClass == "spawned_weapon" then  
-                        slot.WeaponClass = ent:GetWeaponClass()
-                    else
-                        slot.WeaponClass = nil
-                    end  
-                    saveData(self, eq,"Inventory")
-                    if ent:GetClass() == "spawned_weapon" and ent:Getamount() > 1 then 
-                        ent:Setamount(ent:Getamount()-1)
-                    else
-                        ent:Remove()
-                    end
-                    self:EmitSound(InventoryConfig.Sounds.pickUp)
-                    return
+                slot.isOccupied = true
+                if ent.Name ~= nil then
+                    slot.Name = ent.Name
                 else
-                    showNotification(self, InventoryConfig.Messages.tooHeavy)
-                    return
+                    slot.Name = ent:GetClass()
                 end
-            end  
+                slot.ItemClass = ent:GetClass()
+                slot.Count = slot.Count + 1
+                slot.Model = ent:GetModel()
+                slot.MaxStack = ent.StackSize
+                if slot.ItemClass == "spawned_weapon" then
+                    slot.WeaponClass = ent:GetWeaponClass()
+                else
+                    slot.WeaponClass = nil
+                end
+                saveData(self, eq,"Inventory")
+                if ent:GetClass() == "spawned_weapon" and ent:Getamount() > 1 then
+                    ent:Setamount(ent:Getamount()-1)
+                else
+                    ent:Remove()
+                end
+                self:EmitSound(InventoryConfig.Sounds.pickUp)
+                return
+            end
         end
         -- no space
         showNotification(ply, InventoryConfig.Messages.noSpace)
@@ -279,18 +275,10 @@ if SERVER then
         local whereDropped = net.ReadString()
         local inv = loadData(ply,"Inventory")
         local bank = loadData(ply,"Bank")
-        if whereDropped == "Inventory" then 
-            local totalWeight = getTotalWeight(inv)
-            if not ((totalWeight+(inv[item1].Count+bank[item2].Count)*bank[item2].SingleWeight) <= getMaxWeight(ply, whereDropped)) then
-                showNotification(ply, InventoryConfig.Messages.tooHeavy)
-                return 
-            end
+        if whereDropped == "Inventory" then
+            -- nothing to check when weight system is disabled
         else
-            local totalWeight = getTotalWeight(bank)
-            if not ((totalWeight+(inv[item1].Count+bank[item2].Count)*inv[item1].SingleWeight) <= getMaxWeight(ply, whereDropped)) then
-                showNotification(ply, InventoryConfig.Messages.tooHeavy)
-                return  
-            end
+            -- nothing to check when weight system is disabled
         end
         if inv[item1].Name == bank[item2].Name and inv[item1].ItemClass == bank[item2].ItemClass and inv[item1].Count+bank[item2].Count <=bank[item2].MaxStack then
             if whereDropped == "Inventory" then 

--- a/inventory/lua/inv_config.lua
+++ b/inventory/lua/inv_config.lua
@@ -16,24 +16,16 @@ InventoryConfig = {
         openStorage = "items/ammo_pickup.wav",
     },
     Groups = {
-        user = { 
-            inventoryMaxWeight = 30, 
-            bankMaxWeight = 250,
-        },
-        vip = { 
-            inventoryMaxWeight = 45, 
-            bankMaxWeight = 450,
-        } 
+        user = {},
+        vip = {}
     },
     Messages = {
         noSpace = "No space in inventory.",
-        tooHeavy = "Too Heavy.",
     },
     GuiText = {
         use = "Use",
         drop = "Drop",
         dropAll = "Drop All",
-        totalWeight = "Вес: ",
     },
 }
   


### PR DESCRIPTION
## Summary
- remove weight limitations and associated UI labels
- extend inventory slot count to 40 with scroll panel
- adjust server logic to handle 40 inventory slots
- update helper loops for new slot count
- simplify configuration without weight data

## Testing
- `luajit` unavailable so no automated Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_684987b4ad308328ae098b0cf1f2d6e6