### PR TITLE
Fix trade init and slot update

### DIFF
--- a/inventory/lua/autorun/client/inv_bank_gui.lua
+++ b/inventory/lua/autorun/client/inv_bank_gui.lua
@@ -15,14 +15,7 @@ if CLIENT then
     Invenotry_Gui.BankFrame:SetDeleteOnClose(false)  
     Invenotry_Gui.BankFrame:SetVisible(false)  
  
-    local WeightLabel = vgui.Create("DLabel", Invenotry_Gui.BankFrame) 
-    local fx, fy = Invenotry_Gui.BankFrame:GetSize()
-    WeightLabel:SetSize(fx, 50)
-    WeightLabel:SetPos(0,fy-55)  
-    WeightLabel:SetContentAlignment( 5 )  
-    WeightLabel:SetColor(InventoryConfig.Colors.textColor)
-    WeightLabel:SetFont("WeightFont")               
-    WeightLabel:SetText(InventoryConfig.GuiText.totalWeight.."0 / "..getMaxWeight(LocalPlayer(), "Хранилище").." кг")
+    -- Weight system removed
 
     net.Receive( "openBankGui", function( len, player )
         local invW, invH = Invenotry_Gui.InvFrame:GetSize()
@@ -44,19 +37,16 @@ if CLIENT then
     local lastTime=0  
     function refreshBank(tab)
         if tab ~= nil then
-            local totalWeight = 0
-            for i = 1, 32 do 
-                LocalPlayer().BankSlots[i].IsOccupied  = tab[i].IsOccupied 
-                LocalPlayer().BankSlots[i].VGui:SetCount(tab[i].Count)  
+            for i = 1, 32 do
+                LocalPlayer().BankSlots[i].IsOccupied  = tab[i].IsOccupied
+                LocalPlayer().BankSlots[i].VGui:SetCount(tab[i].Count)
                 if tab[i].Model ~= nil and tab[i].Count > 0 then
-                    LocalPlayer().BankSlots[i].VGui:SetModel(tab[i].Model) 
-                end 
-                LocalPlayer().BankSlots[i].VGui:SetName(tab[i].Name) 
-                LocalPlayer().BankSlots[i].VGui:SetItemClass(tab[i].ItemClass) 
-                LocalPlayer().BankSlots[i].VGui:SetWeaponClass(tab[i].WeaponClass) 
-                totalWeight = (totalWeight + (tonumber(tab[i].SingleWeight) * tonumber(tab[i].Count)))
-            end 
-            WeightLabel:SetText(InventoryConfig.GuiText.totalWeight..totalWeight.." / "..getMaxWeight(LocalPlayer(), "Хранилище").." кг")
+                    LocalPlayer().BankSlots[i].VGui:SetModel(tab[i].Model)
+                end
+                LocalPlayer().BankSlots[i].VGui:SetName(tab[i].Name)
+                LocalPlayer().BankSlots[i].VGui:SetItemClass(tab[i].ItemClass)
+                LocalPlayer().BankSlots[i].VGui:SetWeaponClass(tab[i].WeaponClass)
+            end
         end
     end 
     net.Receive( "forceRefresh_bank", function( len, ply ) refreshBank(net.ReadTable())  end)
@@ -84,8 +74,8 @@ if CLIENT then
                  ply.BankSlots[e].VGui:SetAlpha(255) 
                 end
             end
-            for e = 1, 16 do
-                ply.InventorySlots[e].VGui:SetAlpha(255) 
+            for e = 1, 40 do
+                ply.InventorySlots[e].VGui:SetAlpha(255)
             end
             if drop then
                 -- drop na bank  
@@ -109,8 +99,8 @@ if CLIENT then
                  ply.BankSlots[e].VGui:SetAlpha(255) 
                 end
             end
-            for e = 1, 16 do
-                ply.InventorySlots[e].VGui:SetAlpha(255) 
+            for e = 1, 40 do
+                ply.InventorySlots[e].VGui:SetAlpha(255)
             end
             if drop then
                 net.Start("swapItems_inv")

--- a/inventory/lua/autorun/client/inv_gui.lua
+++ b/inventory/lua/autorun/client/inv_gui.lua
@@ -19,21 +19,11 @@ if CLIENT then
             Invenotry_Gui.InvFrame:SetDeleteOnClose(false)
             Invenotry_Gui.InvFrame:SetVisible(false)
 
-            local WeightLabel = vgui.Create("DLabel", Invenotry_Gui.InvFrame)
-            local fx, fy = Invenotry_Gui.InvFrame:GetSize()
-            WeightLabel:SetSize(fx, 50)
-            WeightLabel:SetPos(0, fy - 55)
-            WeightLabel:SetContentAlignment(5)
-            WeightLabel:SetFont("WeightFont")
-            WeightLabel:SetColor(InventoryConfig.Colors.textColor)
-            WeightLabel:SetText(
-                InventoryConfig.GuiText.totalWeight .. "0 / " .. getMaxWeight(LocalPlayer(), "Рюкзак") .. " кг"
-            )
+            -- Weight system removed
             local lastTime = 0
             function refreshInv(tab)
                 if tab ~= nil then
-                    local totalWeight = 0
-                    for i = 1, 16 do
+                    for i = 1, 40 do
                         LocalPlayer().InventorySlots[i].IsOccupied = tab[i].IsOccupied
                         LocalPlayer().InventorySlots[i].VGui:SetCount(tab[i].Count)
                         if tab[i].Model ~= nil and tab[i].Count > 0 then
@@ -43,12 +33,7 @@ if CLIENT then
                         LocalPlayer().InventorySlots[i].VGui:SetName(tab[i].Name)
                         LocalPlayer().InventorySlots[i].VGui:SetItemClass(tab[i].ItemClass)
                         LocalPlayer().InventorySlots[i].VGui:SetWeaponClass(tab[i].WeaponClass)
-                        totalWeight = (totalWeight + (tonumber(tab[i].SingleWeight) * tonumber(tab[i].Count)))
                     end
-                    WeightLabel:SetText( 
-                        InventoryConfig.GuiText.totalWeight ..
-                            totalWeight .. " / " .. getMaxWeight(LocalPlayer(), "Inventory") .. " кг"
-                    )
                 end
             end
             net.Receive(
@@ -87,7 +72,7 @@ if CLIENT then
                             else
                                 net.Start("inv_requestUpdate")
                                 net.SendToServer()
-                                for e = 1, 16 do
+                                for e = 1, 40 do
                                     ply.InventorySlots[e].VGui:SetAlpha(255)
                                 end
                                 for e = 1, 32 do
@@ -106,13 +91,17 @@ if CLIENT then
             end
             hook.Add("Think", "bindThinkInv", bindThinkInv)
 
-            local grid = vgui.Create("DGrid", Invenotry_Gui.InvFrame)
-            grid:SetPos(10 * scale, 30 * scale)
+            local scroll = vgui.Create("DScrollPanel", Invenotry_Gui.InvFrame)
+            scroll:SetPos(10 * scale, 30 * scale)
+            scroll:SetSize(72 * 4, 72 * 4)
+
+            local grid = vgui.Create("DGrid", scroll)
+            grid:Dock(FILL)
             grid:SetCols(4)
             grid:SetColWide(72)
             grid:SetRowHeight(72)
 
-            for i = 1, 16 do
+            for i = 1, 40 do
                 ply.InventorySlots[i] = {}
                 ply.InventorySlots[i].VGui = vgui.Create("inv_slot", Invenotry_Gui.InvFrame)
                 ply.InventorySlots[i].IsOccupied = false
@@ -125,11 +114,11 @@ if CLIENT then
                     function(pnl, item, drop, i, x, y)
                         item = item[1]
                         if pnl.Id == nil then
-                            for e = 1, 16 do
+                            for e = 1, 40 do
                                 ply.InventorySlots[e].VGui:SetAlpha(255)
                             end
                         end
-                        for e = 1, 16 do
+                        for e = 1, 40 do
                             if ply.InventorySlots[e].VGui.Id == pnl.Id then
                                 ply.InventorySlots[e].VGui:SetAlpha(100)
                             else
@@ -155,7 +144,7 @@ if CLIENT then
                     "inv_droppingFromBank",
                     function(pnl, item, drop, i, x, y)
                         item = item[1]
-                        for e = 1, 16 do
+                        for e = 1, 40 do
                             if ply.InventorySlots[e].VGui.Id == pnl.Id then
                                 ply.InventorySlots[e].VGui:SetAlpha(100)
                             else

--- a/inventory/lua/autorun/client/inv_init_c.lua
+++ b/inventory/lua/autorun/client/inv_init_c.lua
@@ -30,10 +30,10 @@ end
 
 hook.Add( "Think", "clearAlphaIfNeeded", function()
     if not input.IsMouseDown(MOUSE_LEFT) and (Invenotry_Gui.InvFrame:IsVisible() or Invenotry_Gui.BankFrame:IsVisible()) then
-        for e=1,32 do  
+        for e=1,32 do
             LocalPlayer().BankSlots[e].VGui:SetAlpha(255)
         end
-        for e=1,16 do   
+        for e=1,40 do
             LocalPlayer().InventorySlots[e].VGui:SetAlpha(255)
         end
     end

--- a/inventory/lua/autorun/client/inv_trade_gui.lua
+++ b/inventory/lua/autorun/client/inv_trade_gui.lua
@@ -1,0 +1,133 @@
+include('inv_config.lua')
+include('inv_shared.lua')
+include('autorun/client/inv_base_slot.lua')
+include('autorun/client/inv_base_window.lua')
+if CLIENT then
+    local function createTradeSlots(parent, startIndex, count)
+        local grid = vgui.Create('DGrid', parent)
+        grid:SetCols(5)
+        grid:SetColWide(72)
+        grid:SetRowHeight(72)
+        local slots = {}
+        for i = 1, count do
+            local s = vgui.Create('inv_slot', parent)
+            s:SetSize(70, 70)
+            s.Highlighted = false
+            s.Id = startIndex + i - 1
+            grid:AddItem(s)
+            slots[i] = s
+        end
+        return grid, slots
+    end
+
+    local myData, otherData
+    local partner
+    net.Receive('trade_open', function()
+        partner = net.ReadEntity()
+        myData = net.ReadTable()
+        otherData = net.ReadTable()
+
+        if IsValid(Invenotry_Gui.TradeFrame) then Invenotry_Gui.TradeFrame:Remove() end
+        Invenotry_Gui.TradeFrame = vgui.Create('inv_window')
+        Invenotry_Gui.TradeFrame:SetTitle('Trade with ' .. partner:Nick())
+        Invenotry_Gui.TradeFrame:SetSize(72 * 8 + 80, 420)
+        Invenotry_Gui.TradeFrame:Center()
+        Invenotry_Gui.TradeFrame:ShowCloseButton(true)
+        Invenotry_Gui.TradeFrame:SetVisible(true)
+
+        local scrollL = vgui.Create('DScrollPanel', Invenotry_Gui.TradeFrame)
+        scrollL:SetPos(10, 30)
+        scrollL:SetSize(72 * 4, 72 * 4)
+        local gridL = vgui.Create('DGrid', scrollL)
+        gridL:Dock(FILL)
+        gridL:SetCols(4)
+        gridL:SetColWide(72)
+        gridL:SetRowHeight(72)
+
+        LocalPlayer().TradeSlotsL = {}
+        for i = 1, 40 do
+            local slot = vgui.Create('inv_slot', Invenotry_Gui.TradeFrame)
+            slot.Id = i
+            slot:SetModel(myData[i].Model)
+            slot:SetCount(myData[i].Count)
+            slot:SetName(myData[i].Name)
+            slot:SetItemClass(myData[i].ItemClass)
+            slot:SetWeaponClass(myData[i].WeaponClass)
+            slot.Icon.DoClick = function()
+                net.Start('trade_select')
+                net.WriteBool(true)
+                net.WriteUInt(slot.Id, 8)
+                net.SendToServer()
+            end
+            gridL:AddItem(slot)
+            LocalPlayer().TradeSlotsL[i] = slot
+        end
+
+        local scrollR = vgui.Create('DScrollPanel', Invenotry_Gui.TradeFrame)
+        scrollR:SetPos(Invenotry_Gui.TradeFrame:GetWide() - (72 * 4 + 10), 30)
+        scrollR:SetSize(72 * 4, 72 * 4)
+        local gridR = vgui.Create('DGrid', scrollR)
+        gridR:Dock(FILL)
+        gridR:SetCols(4)
+        gridR:SetColWide(72)
+        gridR:SetRowHeight(72)
+
+        LocalPlayer().TradeSlotsR = {}
+        for i = 1, 40 do
+            local slot = vgui.Create('inv_slot', Invenotry_Gui.TradeFrame)
+            slot.Id = i
+            slot:SetModel(otherData[i].Model)
+            slot:SetCount(otherData[i].Count)
+            slot:SetName(otherData[i].Name)
+            slot:SetItemClass(otherData[i].ItemClass)
+            slot:SetWeaponClass(otherData[i].WeaponClass)
+            slot.Icon.DoClick = function()
+                net.Start('trade_select')
+                net.WriteBool(false)
+                net.WriteUInt(slot.Id, 8)
+                net.SendToServer()
+            end
+            gridR:AddItem(slot)
+            LocalPlayer().TradeSlotsR[i] = slot
+        end
+
+        local centerPanel = vgui.Create('DPanel', Invenotry_Gui.TradeFrame)
+        centerPanel:SetSize(72 * 5, 150)
+        centerPanel:SetPos((Invenotry_Gui.TradeFrame:GetWide() - centerPanel:GetWide()) / 2, 30)
+        local gridC, tradeSlots = createTradeSlots(centerPanel, 1, 10)
+        gridC:Dock(FILL)
+        LocalPlayer().TradeCenterSlots = tradeSlots
+
+        Invenotry_Gui.TradeFrame.Approve = vgui.Create('DButton', Invenotry_Gui.TradeFrame)
+        Invenotry_Gui.TradeFrame.Approve:SetText('Approve (0/2)')
+        Invenotry_Gui.TradeFrame.Approve:SetPos((Invenotry_Gui.TradeFrame:GetWide() - 120) / 2, centerPanel:GetY() + centerPanel:GetTall() + 10)
+        Invenotry_Gui.TradeFrame.Approve:SetSize(120, 25)
+        Invenotry_Gui.TradeFrame.Approve.DoClick = function()
+            net.Start('trade_confirm')
+            net.SendToServer()
+        end
+    end)
+
+    net.Receive('trade_update', function()
+        partner = net.ReadEntity()
+        local myOffers = net.ReadTable()
+        local myWants = net.ReadTable()
+        local myC = net.ReadBool()
+        local otherOffers = net.ReadTable()
+        local otherWants = net.ReadTable()
+        local otherC = net.ReadBool()
+
+        local approved = 0
+        if myC then approved = approved + 1 end
+        if otherC then approved = approved + 1 end
+        if IsValid(Invenotry_Gui.TradeFrame) then
+            Invenotry_Gui.TradeFrame.Approve:SetText('Approve (' .. approved .. '/2)')
+        end
+    end)
+
+    net.Receive('trade_end', function()
+        if IsValid(Invenotry_Gui.TradeFrame) then
+            Invenotry_Gui.TradeFrame:Close()
+        end
+    end)
+end

--- a/inventory/lua/autorun/server/inv_init.lua
+++ b/inventory/lua/autorun/server/inv_init.lua
@@ -7,7 +7,8 @@ if SERVER then
     AddCSLuaFile( "lua/autorun/client/inv_gui.lua")
     AddCSLuaFile( "lua/autorun/client/inv_bank_gui.lua")
     AddCSLuaFile( "lua/autorun/client/inv_init_c.lua")
-    AddCSLuaFile( "lua/inv_shared.lua")   
+    AddCSLuaFile( "lua/autorun/client/inv_trade_gui.lua")
+    AddCSLuaFile( "lua/inv_shared.lua")
     AddCSLuaFile( "lua/inv_config.lua")
  
     util.AddNetworkString( "dropEnt_inv" )
@@ -21,40 +22,152 @@ if SERVER then
     util.AddNetworkString( "transferItems_inv" )
     util.AddNetworkString( "validateFiles_inv" )
 
+    -- trading
+    util.AddNetworkString( "trade_open" )
+    util.AddNetworkString( "trade_select" )
+    util.AddNetworkString( "trade_confirm" )
+    util.AddNetworkString( "trade_update" )
+    util.AddNetworkString( "trade_end" )
+
 
     util.AddNetworkString( "inv_requestUpdate" )
+
+    -- state for player trades
+    local ActiveTrades = {}
+
+    local loadData
+    local saveData
+
+    local function clearSlot()
+        return {
+            isOccupied = false,
+            Count = 0,
+            Name = "unknown",
+            ItemClass = "unknown",
+            WeaponClass = "unknown",
+            SingleWeight = 0,
+            MaxStack = 20
+        }
+    end
+
+    local function insertItem(inv, data)
+        for i = 1, 40 do
+            local s = inv[i]
+            if s.ItemClass == data.ItemClass and s.Name == data.Name and s.Count + data.Count <= (s.MaxStack or data.MaxStack or 20) then
+                s.Count = s.Count + data.Count
+                s.isOccupied = true
+                return true
+            end
+        end
+        for i = 1, 40 do
+            local s = inv[i]
+            if not s.isOccupied then
+                inv[i] = table.Copy(data)
+                return true
+            end
+        end
+        return false
+    end
+
+    local function tradeBroadcast(p1, p2)
+        local s1, s2 = ActiveTrades[p1], ActiveTrades[p2]
+        if not s1 or not s2 then return end
+        net.Start("trade_update")
+        net.WriteEntity(p2)
+        net.WriteTable(s1.offers)
+        net.WriteTable(s1.wants)
+        net.WriteBool(s1.confirmed)
+        net.WriteTable(s2.offers)
+        net.WriteTable(s2.wants)
+        net.WriteBool(s2.confirmed)
+        net.Send({p1, p2})
+    end
+
+    local function endTrade(p1, p2)
+        ActiveTrades[p1] = nil
+        ActiveTrades[p2] = nil
+        net.Start("trade_end")
+        net.Send({p1, p2})
+    end
+
+    local function finalizeTrade(p1, p2)
+        local inv1 = loadData(p1, "Inventory")
+        local inv2 = loadData(p2, "Inventory")
+        for id in pairs(ActiveTrades[p1].offers) do
+            local slot = inv1[id]
+            if slot and slot.Count > 0 then
+                if not insertItem(inv2, slot) then
+                    showNotification(p1, InventoryConfig.Messages.noSpace)
+                    showNotification(p2, InventoryConfig.Messages.noSpace)
+                    endTrade(p1, p2)
+                    return
+                end
+                inv1[id] = clearSlot()
+            end
+        end
+        for id in pairs(ActiveTrades[p2].offers) do
+            local slot = inv2[id]
+            if slot and slot.Count > 0 then
+                if not insertItem(inv1, slot) then
+                    showNotification(p1, InventoryConfig.Messages.noSpace)
+                    showNotification(p2, InventoryConfig.Messages.noSpace)
+                    endTrade(p1, p2)
+                    return
+                end
+                inv2[id] = clearSlot()
+            end
+        end
+        saveData(p1, inv1, "Inventory")
+        saveData(p2, inv2, "Inventory")
+        endTrade(p1, p2)
+    end
+
+    local function startTrade(p1, p2)
+        ActiveTrades[p1] = {partner = p2, offers = {}, wants = {}, confirmed = false}
+        ActiveTrades[p2] = {partner = p1, offers = {}, wants = {}, confirmed = false}
+
+        net.Start("trade_open")
+        net.WriteEntity(p2)
+        net.WriteTable(loadData(p1, "Inventory"))
+        net.WriteTable(loadData(p2, "Inventory"))
+        net.Send(p1)
+
+        net.Start("trade_open")
+        net.WriteEntity(p1)
+        net.WriteTable(loadData(p2, "Inventory"))
+        net.WriteTable(loadData(p1, "Inventory"))
+        net.Send(p2)
+    end
 
     local function showNotification(ply, msg)
         net.Start("inv_showNotification")
         net.WriteString(msg)
-        net.Send(ply) 
+        net.Send(ply)
     end
-    local function getTotalWeight(tab)
-        local totalWeight = 0
-        for i, val in ipairs(tab) do
-            totalWeight = totalWeight+(val.SingleWeight * val.Count)
-        end 
-        return totalWeight
-    end
+    -- Weight related functions removed
 
-    local function saveData()end
-    local function loadData(ply, typ) 
-        if file.Exists( InventoryConfig.General.playerDataFolder.."/"..ply:SteamID64().."_"..typ..".dat", "DATA" ) then
-            return util.JSONToTable(file.Read( InventoryConfig.General.playerDataFolder.."/"..ply:SteamID64().."_"..typ..".dat", "DATA" ))
+    local function loadData(ply, typ)
+        local path = InventoryConfig.General.playerDataFolder .. "/" .. ply:SteamID64() .. "_" .. typ .. ".dat"
+        if file.Exists(path, "DATA") then
+            local data = util.JSONToTable(file.Read(path, "DATA")) or {}
+            local max = typ == "Inventory" and 40 or 32
+            for i = 1, max do
+                data[i] = data[i] or clearSlot()
+                if data[i].MaxStack == nil then
+                    data[i].MaxStack = 20
+                end
+            end
+            return data
         else
             local eq = {}
-            local range=0
-            if typ == "Inventory" then range = 16 else range = 32 end
-            for i=1,range do
-                eq[i] = {}
-                eq[i].isOccupied = false 
-                eq[i].Count = 0 
-                eq[i].Name = "unknown"
-                eq[i].ItemClass = "unknown"
-                eq[i].WeaponClass = "unknown"
-                eq[i].SingleWeight = 0
+            local range = typ == "Inventory" and 40 or 32
+            for i = 1, range do
+                eq[i] = clearSlot()
             end
-            saveData(ply, eq, typ)
+            if not file.Exists(InventoryConfig.General.playerDataFolder, "DATA") then
+                file.CreateDir(InventoryConfig.General.playerDataFolder)
+            end
+            file.Write(path, util.TableToJSON(eq))
             return eq
         end
     end
@@ -180,57 +293,53 @@ if SERVER then
     local plyMeta = FindMetaTable( "Player" )         
     function plyMeta:AddInventoryItem(ent, count)
         local eq = loadData(self,"Inventory")  
-        if eq == nil then 
-            eq = {} 
-            for i=1,16 do
+        if eq == nil then
+            eq = {}
+            for i=1,40 do
                 eq[i] = {}
-                eq[i].isOccupied = false 
+                eq[i].isOccupied = false
                 eq[i].Count = 0
                 eq[i].Name = "unknown"
                 eq[i].ItemClass = "unknown"
                 eq[i].WeaponClass = "unknown"
                 eq[i].SingleWeight = 0
             end
-        end 
-        local totalWeight = getTotalWeight(eq)
+        end
         for i, slot in ipairs(eq) do
             if ent.StackSize == nil then ent.StackSize = 1 end
-            if slot.isOccupied == false or (ent.StackSize > slot.Count and slot.ItemClass == ent:GetClass()) then 
+            if slot.isOccupied == false or (ent.StackSize > slot.Count and slot.ItemClass == ent:GetClass()) then
                 if ent.Weight ~= nil then
                     slot.SingleWeight = ent.Weight
                 else
                     slot.SingleWeight = 1
                 end
-                if (slot.SingleWeight + totalWeight) <= getMaxWeight(self, "Inventory") then 
-                    slot.isOccupied = true
-                    if ent.Name ~= nil then slot.Name = ent.Name else
-                        slot.Name = ent:GetClass()
-                    end
-                    slot.ItemClass = ent:GetClass() 
-                    slot.Count = slot.Count + 1
-                    slot.Model = ent:GetModel() 
-                    slot.MaxStack = ent.StackSize
-                    if slot.ItemClass == "spawned_weapon" then  
-                        slot.WeaponClass = ent:GetWeaponClass()
-                    else
-                        slot.WeaponClass = nil
-                    end  
-                    saveData(self, eq,"Inventory")
-                    if ent:GetClass() == "spawned_weapon" and ent:Getamount() > 1 then 
-                        ent:Setamount(ent:Getamount()-1)
-                    else
-                        ent:Remove()
-                    end
-                    self:EmitSound(InventoryConfig.Sounds.pickUp)
-                    return
+                slot.isOccupied = true
+                if ent.Name ~= nil then
+                    slot.Name = ent.Name
                 else
-                    showNotification(self, InventoryConfig.Messages.tooHeavy)
-                    return
+                    slot.Name = ent:GetClass()
                 end
-            end  
+                slot.ItemClass = ent:GetClass()
+                slot.Count = slot.Count + 1
+                slot.Model = ent:GetModel()
+                slot.MaxStack = ent.StackSize
+                if slot.ItemClass == "spawned_weapon" then
+                    slot.WeaponClass = ent:GetWeaponClass()
+                else
+                    slot.WeaponClass = nil
+                end
+                saveData(self, eq,"Inventory")
+                if ent:GetClass() == "spawned_weapon" and ent:Getamount() > 1 then
+                    ent:Setamount(ent:Getamount()-1)
+                else
+                    ent:Remove()
+                end
+                self:EmitSound(InventoryConfig.Sounds.pickUp)
+                return
+            end
         end
         -- no space
-        showNotification(ply, InventoryConfig.Messages.noSpace)
+        showNotification(self, InventoryConfig.Messages.noSpace)
     end
  
 
@@ -259,9 +368,9 @@ if SERVER then
         if item1 == item2 then return end -- in case you're trying to drag this same item on itself
         local type = net.ReadString()
         local eq = loadData(ply,type) 
-        if  eq[item1].ItemClass == eq[item2].ItemClass and 
-            eq[item1].Name == eq[item2].Name and 
-            eq[item1].Count+eq[item2].Count <= eq[item2].MaxStack then
+        if  eq[item1].ItemClass == eq[item2].ItemClass and
+            eq[item1].Name == eq[item2].Name and
+            eq[item1].Count + eq[item2].Count <= (eq[item2].MaxStack or eq[item1].MaxStack or 20) then
                 eq[item1].Count = eq[item2].Count + eq[item1].Count
                 eq[item2].isOccupied = false
                 eq[item2].Count = 0 
@@ -279,20 +388,13 @@ if SERVER then
         local whereDropped = net.ReadString()
         local inv = loadData(ply,"Inventory")
         local bank = loadData(ply,"Bank")
-        if whereDropped == "Inventory" then 
-            local totalWeight = getTotalWeight(inv)
-            if not ((totalWeight+(inv[item1].Count+bank[item2].Count)*bank[item2].SingleWeight) <= getMaxWeight(ply, whereDropped)) then
-                showNotification(ply, InventoryConfig.Messages.tooHeavy)
-                return 
-            end
+        if whereDropped == "Inventory" then
+            -- nothing to check when weight system is disabled
         else
-            local totalWeight = getTotalWeight(bank)
-            if not ((totalWeight+(inv[item1].Count+bank[item2].Count)*inv[item1].SingleWeight) <= getMaxWeight(ply, whereDropped)) then
-                showNotification(ply, InventoryConfig.Messages.tooHeavy)
-                return  
-            end
+            -- nothing to check when weight system is disabled
         end
-        if inv[item1].Name == bank[item2].Name and inv[item1].ItemClass == bank[item2].ItemClass and inv[item1].Count+bank[item2].Count <=bank[item2].MaxStack then
+        if inv[item1].Name == bank[item2].Name and inv[item1].ItemClass == bank[item2].ItemClass and
+            inv[item1].Count + bank[item2].Count <= (bank[item2].MaxStack or inv[item1].MaxStack or 20) then
             if whereDropped == "Inventory" then 
                 inv[item1].Count = inv[item1].Count+bank[item2].Count
                 bank[item2].isOccupied = false
@@ -315,5 +417,58 @@ if SERVER then
         sound.Play( InventoryConfig.Sounds.dragItem, ply:GetPos() )
         saveData(ply, bank,"Bank")
         saveData(ply, inv,"Inventory")
+    end)
+
+    net.Receive("trade_select", function(len, ply)
+        local own = net.ReadBool()
+        local slot = net.ReadUInt(8)
+        local s = ActiveTrades[ply]
+        if not s then return end
+        s.confirmed = false
+        ActiveTrades[s.partner].confirmed = false
+        local tbl = own and s.offers or s.wants
+        if tbl[slot] then
+            tbl[slot] = nil
+        else
+            tbl[slot] = true
+        end
+        tradeBroadcast(ply, s.partner)
+    end)
+
+    net.Receive("trade_confirm", function(len, ply)
+        local s = ActiveTrades[ply]
+        if not s then return end
+        s.confirmed = true
+        tradeBroadcast(ply, s.partner)
+        if ActiveTrades[s.partner] and ActiveTrades[s.partner].confirmed then
+            finalizeTrade(ply, s.partner)
+        end
+    end)
+
+    hook.Add("PlayerSay", "inventory_trade_cmd", function(ply, text)
+        if string.Trim(string.lower(text)) == "/trade nearby" then
+            local target
+            for _, p in ipairs(player.GetAll()) do
+                if p ~= ply and p:GetPos():Distance(ply:GetPos()) <= 100 then
+                    target = p
+                    break
+                end
+            end
+            if target then
+                if not ActiveTrades[ply] and not ActiveTrades[target] then
+                    startTrade(ply, target)
+                end
+            else
+                showNotification(ply, "No nearby player")
+            end
+            return ""
+        end
+    end)
+
+    hook.Add("PlayerDisconnected", "inventory_trade_cleanup", function(ply)
+        local s = ActiveTrades[ply]
+        if s then
+            endTrade(ply, s.partner)
+        end
     end)
 end

--- a/inventory/lua/entities/example_heavy_item/shared.lua
+++ b/inventory/lua/entities/example_heavy_item/shared.lua
@@ -11,7 +11,7 @@ ENT.AdminSpawnable = true
 
 -- Here inventory variables goes:
 ENT.Pickable = true -- That makes us able to pick up this item
-ENT.StackSize = 2 -- [optional] Make it 1 if you don't want to stack this item in inventory
+ENT.StackSize = 20 -- [optional] Maximum items per stack
 ENT.Weight = 11 -- [optional]
 ENT.Name = "Example Heavy Item" -- [optional]
 -- 

--- a/inventory/lua/entities/medickit/shared.lua
+++ b/inventory/lua/entities/medickit/shared.lua
@@ -11,7 +11,7 @@ ENT.AdminSpawnable = true
 
 -- Here inventory variables goes:
 ENT.Pickable = true -- That makes us able to pick up this item
-ENT.StackSize = 2 -- [optional] Make it 1 if you don't want to stack this item in inventory
+ENT.StackSize = 20 -- [optional] Maximum items per stack
 ENT.Weight = 3 -- [optional]
 ENT.Name = "Medic Kit" -- [optional]
 -- 

--- a/inventory/lua/inv_config.lua
+++ b/inventory/lua/inv_config.lua
@@ -16,24 +16,16 @@ InventoryConfig = {
         openStorage = "items/ammo_pickup.wav",
     },
     Groups = {
-        user = { 
-            inventoryMaxWeight = 30, 
-            bankMaxWeight = 250,
-        },
-        vip = { 
-            inventoryMaxWeight = 45, 
-            bankMaxWeight = 450,
-        } 
+        user = {},
+        vip = {}
     },
     Messages = {
         noSpace = "No space in inventory.",
-        tooHeavy = "Too Heavy.",
     },
     GuiText = {
         use = "Use",
         drop = "Drop",
         dropAll = "Drop All",
-        totalWeight = "Вес: ",
     },
 }
   


### PR DESCRIPTION
## Summary
- declare load/save helpers before trade functions
- rewrite `loadData` to avoid nested net messages
- fix notification call when inventory is full

## Testing
- `lua -v`
- `luac -p inventory/lua/autorun/server/inv_init.lua`

------
https://chatgpt.com/codex/tasks/task_e_684987b4ad308328ae098b0cf1f2d6e6